### PR TITLE
[Fix] lua branch has removed in lukas-reineke/indent-blankline.nvim

### DIFF
--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -17,7 +17,6 @@ ui['glepnir/galaxyline.nvim'] = {
 
 ui['lukas-reineke/indent-blankline.nvim'] = {
   event = 'BufRead',
-  branch = 'lua',
   config = conf.indent_blakline
 }
 


### PR DESCRIPTION
[indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) has not lua branch in recent version and lua code merge to master branch. When we use `PackerUpdate` command, this config will throw error.