### PR TITLE
fix(ui): Fix missing background color in the separator

### DIFF
--- a/lua/modules/ui/eviline.lua
+++ b/lua/modules/ui/eviline.lua
@@ -180,6 +180,7 @@ gls.right[4] = {
 
 gls.right[5] = {
   Separator = {
+    highlight = { colors.fg, colors.bg, 'bold' },
     provider = function()
       return ' '
     end,


### PR DESCRIPTION
## Description

I forgot to put a background to the separator, it is not very noticeable when using zephyr, but in some interfaces it is, so better to have it corrected.