### PR TITLE
Feature pack

### DIFF
--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -33,8 +33,15 @@ function Packer:load_packer()
   end
   packer.init({
     compile_path = packer_compiled,
-    git = { clone_timeout = 120 },
     disable_commands = true,
+    display = {
+      working_sym = 'ﰭ',
+      error_sym = '',
+      done_sym = '',
+      removed_sym = '',
+      moved_sym = 'ﰳ',
+    },
+    git = { clone_timeout = 120 },
   })
   packer.reset()
   local use = packer.use


### PR DESCRIPTION
## Description

- Fix typo error
- Change packer default icons
> PD: The errors in the installation are due to the fact that I do not have the plugins in that path.

![image](https://user-images.githubusercontent.com/62358156/179528858-d674e754-307b-4534-9de8-47dad8448499.png)
