### PR TITLE
Improve Hop keys

### DIFF
--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -147,7 +147,7 @@ end
 function config.hop()
   local hop = require('hop')
   hop.setup({
-    keys = 'etovxqpdygfblzhckisuran',
+    keys = 'asdghklqwertyuiopzxcvbnmfj',
   })
 end
 


### PR DESCRIPTION
## Description
In the hop configuration example, they omit that the config they put is intended for the `bépo keyboard layout`, with the changes I made it makes it much more efficient for `QWERTY`.

> I attach their own reference where they explain all this mess xD
[hop reference](https://github.com/phaazon/hop.nvim/wiki/Configuration#setting-up-your-keys)