### PR TITLE
find the correct lua interpreter

### DIFF
--- a/bin/dope
+++ b/bin/dope
@@ -1,4 +1,4 @@
-#!/usr/local/bin/lua
+#!/usr/bin/env lua
 
 local arguments = {
   install = true,


### PR DESCRIPTION
fix the following issue

```
$ ./bin/dope help
zsh: ./bin/dope: bad interpreter: /usr/local/bin/lua: no such file or directory
[1]    47661 exit 127   ./bin/dope help
```