### PR TITLE
fix: correct unknown method

### DIFF
--- a/lua/core/cli.lua
+++ b/lua/core/cli.lua
@@ -91,7 +91,7 @@ function cli:boot_strap()
   end
   local cmd = 'git clone htts://github.com/folke/lazy.nvim '
   helper.run_git('lazy.nvim', cmd .. self.lazy_dir, 'Install')
-  helper.install_success('lazy.nvim')
+  helper.success('lazy.nvim')
 end
 
 function cli:installer(type)


### PR DESCRIPTION
hello @glepnir 
`dope install` failed to `print` success message, because of unknown method being called. 

I am now using your config. Thank you. When I started `dope` program in `<repo>/bin/dope` did not run as it could not resolve many of its requirable modules such as `cli.lua`  etc. So I copied `dope` program to `<repo>/lua/` directory & able to run. Generally how `dope` is supposed to be run?

Also it required `lua` programming language executables, so i ended up installing those as well in the first place. Can your `README` be updated with these?

--
Thanks.